### PR TITLE
Satora: settle the BTCPay invoice when a swap is claimed

### DIFF
--- a/BTCPayServer.Plugins.Satora/Migrations/20260601_ClaimTxId.cs
+++ b/BTCPayServer.Plugins.Satora/Migrations/20260601_ClaimTxId.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BTCPayServer.Plugins.Satora.Migrations
+{
+    [DbContext(typeof(SatoraPluginDbContext))]
+    [Migration("20260601_ClaimTxId")]
+    public partial class ClaimTxId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ClaimTxId",
+                table: "SatoraTransactions",
+                schema: "BTCPayServer.Plugins.Satora",
+                nullable: true
+            );
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClaimTxId",
+                table: "SatoraTransactions",
+                schema: "BTCPayServer.Plugins.Satora"
+            );
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Satora/Models/SatoraTx.cs
+++ b/BTCPayServer.Plugins.Satora/Models/SatoraTx.cs
@@ -19,7 +19,10 @@ namespace BTCPayServer.Plugins.Satora.Models
 
         public string BTCPayInvoiceId { get; set; }
 
-
+        // Arkade txid of the claim that swept the VHTLC into the store
+        // wallet. Recorded so the BTCPay invoice settlement carries a real
+        // settlement reference, and so a failed settle can be retried.
+        public string? ClaimTxId { get; set; }
 
     }
 }

--- a/BTCPayServer.Plugins.Satora/Plugin.cs
+++ b/BTCPayServer.Plugins.Satora/Plugin.cs
@@ -23,6 +23,7 @@ public class Plugin : BaseBTCPayServerPlugin
                 .AddHostedService<PluginMigrationRunner>()
                 .AddHostedService<SatoraSwapWatcher>()
                 .AddSingleton<SatoraService>()
+                .AddSingleton<SatoraSettlementService>()
                 .AddSingleton<SatoraPluginService>();
     }
 }

--- a/BTCPayServer.Plugins.Satora/Services/SatoraPluginService.cs
+++ b/BTCPayServer.Plugins.Satora/Services/SatoraPluginService.cs
@@ -6,7 +6,7 @@ using uniffi.satora_sdk_ffi;
 
 namespace BTCPayServer.Plugins.Satora.Services
 {
-    public class SatoraPluginService(SatoraPluginDbContextFactory pluginDbContextFactory, ILogger<SatoraPluginService> logger, SatoraService satoraService)
+    public class SatoraPluginService(SatoraPluginDbContextFactory pluginDbContextFactory, ILogger<SatoraPluginService> logger, SatoraService satoraService, SatoraSettlementService settlementService)
     {
 
         public async Task<SatoraSettings> GetStoreSettings(string storeId)
@@ -215,6 +215,7 @@ namespace BTCPayServer.Plugins.Satora.Services
 
                 var swap = await satoraService.GetSwapAsync(swapId, storeSettings.Seed);
                 var statusName = swap.Status.GetType().Name;
+                var originalClaimTxId = dbSwap?.ClaimTxId;
 
                 string action;
                 switch (swap.Status)
@@ -252,13 +253,29 @@ namespace BTCPayServer.Plugins.Satora.Services
                         break;
 
                     case SwapStatus.ServerFunded:
-                        // VHTLC is live — sweep BTC out to destination.
+                        // VHTLC is live — sweep BTC into the store wallet
+                        // (or an operator override), then settle the
+                        // BTCPay invoice with the claim txid.
                         var destination = destinationOverride
                             ?? await satoraService.GetArkadeAddressAsync(storeSettings.Seed);
                         var claimReceipt = await satoraService.ClaimAsync(swapId, destination, storeSettings.Seed);
                         logger.LogInformation("SatoraPlugin:ContinueSwap({SwapId}): claimed {Sats} sats to {Dest}, ark_txid={Txid}",
                             swapId, claimReceipt.ClaimAmountSats, destination, claimReceipt.ArkTxid);
                         action = $"claimed:{claimReceipt.ArkTxid}";
+                        if (dbSwap != null)
+                            dbSwap.ClaimTxId = claimReceipt.ArkTxid;
+                        // Settle is best-effort: if it throws, the claim
+                        // still stands (funds are in the store wallet) and
+                        // the ClientRedeemed branch retries via the manual
+                        // button. Don't let a settle failure unwind the claim.
+                        try
+                        {
+                            await settlementService.SettleAsync(dbSwap?.BTCPayInvoiceId, claimReceipt.ArkTxid, claimReceipt.ClaimAmountSats);
+                        }
+                        catch (Exception se)
+                        {
+                            logger.LogError(se, "SatoraPlugin:ContinueSwap({SwapId}): claim succeeded but invoice settlement failed", swapId);
+                        }
                         swap = await satoraService.GetSwapAsync(swapId, storeSettings.Seed);
                         statusName = swap.Status.GetType().Name;
                         break;
@@ -269,6 +286,22 @@ namespace BTCPayServer.Plugins.Satora.Services
 
                     case SwapStatus.ClientRedeemed:
                     case SwapStatus.ServerRedeemed:
+                        // Already claimed. If a prior settle didn't land
+                        // (transient failure during the claim tick), retry
+                        // it from the recorded claim txid — idempotent on
+                        // the payment outpoint.
+                        if (dbSwap != null && !string.IsNullOrEmpty(dbSwap.ClaimTxId))
+                        {
+                            ulong.TryParse(swap.ReceiveAmount, out var redeemedSats);
+                            try
+                            {
+                                await settlementService.SettleAsync(dbSwap.BTCPayInvoiceId, dbSwap.ClaimTxId, redeemedSats);
+                            }
+                            catch (Exception se)
+                            {
+                                logger.LogWarning(se, "SatoraPlugin:ContinueSwap({SwapId}): settle retry failed", swapId);
+                            }
+                        }
                         action = "complete";
                         break;
 
@@ -278,7 +311,7 @@ namespace BTCPayServer.Plugins.Satora.Services
                         break;
                 }
 
-                if (dbSwap != null && dbSwap.Status != statusName)
+                if (dbSwap != null && (dbSwap.Status != statusName || dbSwap.ClaimTxId != originalClaimTxId))
                 {
                     dbSwap.Status = statusName;
                     _context.SatoraTransactions.Update(dbSwap);

--- a/BTCPayServer.Plugins.Satora/Services/SatoraService.cs
+++ b/BTCPayServer.Plugins.Satora/Services/SatoraService.cs
@@ -51,11 +51,16 @@ namespace BTCPayServer.Plugins.Satora.Services
                     _ => new ChainId.Other(req.BtcNetwork)
                 };
 
-                Address addressTo = req.BtcNetwork switch
+                // Arkade swaps route to the SDK's own internal wallet
+                // (receive_to = null): the plugin claims the BTC into the
+                // store-seed wallet and settles the BTCPay invoice via
+                // PaymentService afterward. BTC / Lightning targets keep
+                // the explicit customer-supplied destination.
+                Address? addressTo = req.BtcNetwork switch
                 {
                     "BTC" => new Address.Bitcoin(req.BtcDestination),
                     "LIGHTNING" => new Address.Lightning(req.BtcDestination),
-                    "ARKADE" => new Address.Arkade(req.BtcDestination),
+                    "ARKADE" => null,
                     _ => new Address()
                 };
 

--- a/BTCPayServer.Plugins.Satora/Services/SatoraSettlementService.cs
+++ b/BTCPayServer.Plugins.Satora/Services/SatoraSettlementService.cs
@@ -1,0 +1,89 @@
+using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Events;
+using BTCPayServer.Payments;
+using BTCPayServer.Services.Invoices;
+using NBitcoin;
+
+namespace BTCPayServer.Plugins.Satora.Services;
+
+// Settles a BTCPay invoice once a Satora swap's BTC has been claimed
+// into the plugin's store wallet.
+//
+// We deliberately do NOT route the swapped BTC to the invoice's own
+// Arkade address — it stays in the SDK's internal (store-seed) wallet —
+// so ArkPayServer's listener never observes it and cannot auto-settle.
+// Instead we register the settlement directly against the invoice using
+// the Arkade claim txid, mirroring exactly what ArkPayServer's own
+// listener does (PaymentData + PaymentService.AddPayment). The invoice
+// ledger then shows a real Arkade payment (amount + method + txid)
+// rather than a bare "marked settled".
+//
+// No compile-time dependency on the ArkPayServer assembly: the payment
+// method id is referenced by string ("ARKADE") and the payment details
+// blob is an anonymous object whose property names match ArkPayServer's
+// ArkadePaymentData(Outpoint, Destination) record, so it round-trips
+// through the handler's serializer.
+public class SatoraSettlementService(
+    PaymentService paymentService,
+    InvoiceRepository invoiceRepository,
+    PaymentMethodHandlerDictionary handlers,
+    EventAggregator eventAggregator,
+    ILogger<SatoraSettlementService> logger)
+{
+    private static readonly PaymentMethodId ArkadePmi = PaymentMethodId.Parse("ARKADE");
+
+    public async Task SettleAsync(string invoiceId, string arkTxid, ulong claimSats)
+    {
+        if (string.IsNullOrEmpty(invoiceId))
+        {
+            logger.LogWarning("SatoraSettlement: no invoice id, nothing to settle");
+            return;
+        }
+
+        var invoice = await invoiceRepository.GetInvoice(invoiceId);
+        if (invoice is null)
+        {
+            logger.LogWarning("SatoraSettlement: invoice {InvoiceId} not found", invoiceId);
+            return;
+        }
+
+        // Payment id keyed on the claim txid so re-running is idempotent
+        // (AddPayment returns null on a duplicate). The Arkade VHTLC claim
+        // produces a single output, so index 0.
+        var outpoint = $"{arkTxid}:0";
+
+        // ArkPayServer not installed, or this invoice has no Arkade prompt
+        // to attach the payment to → fall back to a plain status mark so
+        // the order still settles, just without a payment ledger entry.
+        if (!handlers.TryGetValue(ArkadePmi, out var handler) || invoice.GetPaymentPrompt(ArkadePmi) is null)
+        {
+            logger.LogWarning("SatoraSettlement: no ARKADE handler/prompt for invoice {InvoiceId}; marking settled without a payment record", invoiceId);
+            await invoiceRepository.MarkInvoiceStatus(invoiceId, InvoiceStatus.Settled);
+            return;
+        }
+
+        var details = new { Outpoint = outpoint, Destination = (string?)null };
+        var paymentData = new PaymentData
+        {
+            Status = PaymentStatus.Settled,
+            Amount = Money.Satoshis((long)claimSats).ToDecimal(MoneyUnit.BTC),
+            Created = DateTimeOffset.UtcNow,
+            Id = outpoint,
+            Currency = "BTC",
+        }.Set(invoice, handler, details);
+
+        var payment = await paymentService.AddPayment(paymentData);
+        if (payment is null)
+        {
+            // Already registered on a prior call — idempotent no-op.
+            logger.LogInformation("SatoraSettlement: payment {Outpoint} already registered for invoice {InvoiceId}", outpoint, invoiceId);
+            return;
+        }
+
+        // Nudge the invoice watcher to re-evaluate so it flips to Settled
+        // once payments cover the due (mirrors ArkPayServer).
+        eventAggregator.Publish(new InvoiceNeedUpdateEvent(invoice.Id));
+        logger.LogInformation("SatoraSettlement: registered {Sats} sats Arkade payment (txid {Txid}) for invoice {InvoiceId}", claimSats, arkTxid, invoiceId);
+    }
+}


### PR DESCRIPTION
# Satora: settle the BTCPay invoice when a swap is claimed

Right now we claim the swapped BTC into the store wallet but never actually tell BTCPay the invoice got paid, so the order never settles. 
This wires that last step up.

While I was in there I also cleaned up the create call: 
we were passing the invoice's own Arkade address as `receive_to`, but that address never keyed the VHTLC (the SDK derives the receiver key from the store seed), so it was doing nothing useful. 
I dropped it.

## How it works now

The flow should be coherent end to end:

```
customer pays stablecoin → watcher funds → claim into the store wallet → invoice settled with the claim txid
```

Three pieces:

1. **Create with `receive_to = null` for Arkade.** The swap routes to the SDK's own internal wallet (the store seed). 
We don't need the invoice address at create time anymore. BTC/Lightning targets keep their explicit destination.

2. **Settle the invoice after the claim.** New `SatoraSettlementService` registers a real Arkade payment against the invoice via `PaymentService.AddPayment`, keyed on the claim txid, with the claimed amount and the `ARKADE` method. 
It's basically the same thing `ArkContractInvoiceListener.HandlePaymentData` does, so the invoice ledger shows a proper payment (amount + method + txid), not just a "marked settled" flag.

3. **Persist the claim txid** (`ClaimTxId` column + migration). Makes the settle idempotent. `AddPayment` dedups on the outpoint, and lets a failed settle get retried from the `ClientRedeemed` branch via the Continue button.

The BTC stays in the SDK wallet the whole time; we just credit the invoice with the claim as proof.

## Heads up / known gap

The background watcher treats `ClientRedeemed`/`ServerRedeemed` as terminal, so if the settle ever fails right after a claim, the watcher won't auto-retry it, only the manual Continue button will. 
Settle failures should be rare (it's an in-process DB call), so I left the watcher's terminal logic alone rather than reworking it here. 
If we want fully hands-off recovery we can have the watcher also pick up "redeemed but not yet settled" swaps

--> happy to do that as a follow-up.

## ToDos

- [ ] Run a real checkout, pay the deposit, let the watcher drive it. Once it claims, the invoice should flip to **Settled** with an Arkade payment showing the BTC amount + the claim txid.
- [ ] Re-run Continue on an already-settled swap → no double payment (idempotent on the txid).
