### PR TITLE
Add WooCommerce product source for Shopstr plugin

### DIFF
--- a/BTCPayServer.Plugins.Shopstr/Controllers/ShopstrPluginController.cs
+++ b/BTCPayServer.Plugins.Shopstr/Controllers/ShopstrPluginController.cs
@@ -14,7 +14,7 @@ namespace BTCPayServer.Plugins.Shopstr.Controllers
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     [AutoValidateAntiforgeryToken]
 
-    public class ShopstrPluginController (ShopstrPluginService pluginService, ShopstrService shopstrService) : Controller
+    public class ShopstrPluginController (ShopstrPluginService pluginService, ShopstrService shopstrService, WooCommerceService wooCommerceService) : Controller
     {
 
         [HttpGet]
@@ -103,6 +103,107 @@ namespace BTCPayServer.Plugins.Shopstr.Controllers
                 {
                     if (productsFromShopstr.Any(p => p.Id == item.Id))
                         await shopstrService.CreateShopstrProduct(item, app, nostrSettings, "", true);
+                }
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            finally
+            {
+                shopstrService.DisposeClient();
+            }
+        }
+
+        [HttpPost]
+        [Route("SaveWooCommerceSettings")]
+        public async Task<IActionResult> SaveWooCommerceSettings([FromRoute] string storeId,
+            [FromForm] string wooCommerceUrl, [FromForm] string consumerKey, [FromForm] string consumerSecret,
+            [FromForm] string location, [FromForm] bool flashSales, [FromForm] string condition, [FromForm] string restrictions)
+        {
+            var settings = new WooCommerceSettings
+            {
+                StoreId = storeId,
+                WooCommerceUrl = wooCommerceUrl?.Trim(),
+                ConsumerKey = consumerKey?.Trim(),
+                ConsumerSecret = consumerSecret?.Trim(),
+                Location = location?.Trim() ?? "",
+                FlashSales = flashSales,
+                Condition = Enum.Parse<ConditionEnum>(condition ?? "None"),
+                Restrictions = restrictions ?? ""
+            };
+            await pluginService.UpdateWooCommerceSettings(settings);
+            return Ok();
+        }
+
+        [HttpPost]
+        [Route("PublishWooCommerce")]
+        public async Task<IActionResult> PublishWooCommerce([FromRoute] string storeId)
+        {
+            try
+            {
+                var wcSettings = await pluginService.GetWooCommerceSettings(storeId);
+                if (wcSettings == null || !wcSettings.IsConfigured)
+                    return BadRequest("WooCommerce is not configured");
+
+                var nostrSettings = await pluginService.GetNostrSettings(storeId);
+                if (nostrSettings == null || !nostrSettings.IsConfigured)
+                    return BadRequest("Nostr plugin is not configured");
+
+                var wcApp = await wooCommerceService.FetchProducts(wcSettings);
+                if (!wcApp.ShopItems.Any())
+                    return Ok();
+
+                var baseUrl = wcSettings.WooCommerceUrl.TrimEnd('/');
+                await shopstrService.InitializeClient(nostrSettings.Relays);
+
+                var productsFromShopstr = await shopstrService.GetShopstrProducts(nostrSettings.PubKey);
+
+                foreach (var item in wcApp.ShopItems)
+                {
+                    var existingProduct = productsFromShopstr.FirstOrDefault(p => p.Id == item.Id);
+                    var bPublish = existingProduct == null || !existingProduct.Compare(item, wcApp);
+                    if (bPublish)
+                    {
+                        await shopstrService.CreateShopstrProduct(item, wcApp, nostrSettings, baseUrl);
+                    }
+                }
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            finally
+            {
+                shopstrService.DisposeClient();
+            }
+        }
+
+        [HttpPost]
+        [Route("UnPublishWooCommerce")]
+        public async Task<IActionResult> UnPublishWooCommerce([FromRoute] string storeId)
+        {
+            try
+            {
+                var wcSettings = await pluginService.GetWooCommerceSettings(storeId);
+                if (wcSettings == null || !wcSettings.IsConfigured)
+                    return BadRequest("WooCommerce is not configured");
+
+                var nostrSettings = await pluginService.GetNostrSettings(storeId);
+                var wcApp = await wooCommerceService.FetchProducts(wcSettings);
+                if (!wcApp.ShopItems.Any())
+                    return Ok();
+
+                await shopstrService.InitializeClient(nostrSettings.Relays);
+                var productsFromShopstr = await shopstrService.GetShopstrProducts(nostrSettings.PubKey);
+                productsFromShopstr.RemoveAll(e => !e.Status);
+
+                foreach (var item in wcApp.ShopItems)
+                {
+                    if (productsFromShopstr.Any(p => p.Id == item.Id))
+                        await shopstrService.CreateShopstrProduct(item, wcApp, nostrSettings, "", true);
                 }
                 return Ok();
             }

--- a/BTCPayServer.Plugins.Shopstr/Data/ShopstrDbContext.cs
+++ b/BTCPayServer.Plugins.Shopstr/Data/ShopstrDbContext.cs
@@ -14,6 +14,7 @@ public class ShopstrDbContext : DbContext
     }
 
     public DbSet<ShopstrSettings> Settings { get; set; }
+    public DbSet<WooCommerceSettings> WooCommerceSettings { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/BTCPayServer.Plugins.Shopstr/Migrations/20260606_AddWooCommerce.cs
+++ b/BTCPayServer.Plugins.Shopstr/Migrations/20260606_AddWooCommerce.cs
@@ -1,0 +1,41 @@
+using BTCPayServer.Plugins.Shopstr.Data;
+using BTCPayServer.Plugins.Shopstr.Models;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BTCPayServer.Plugins.Shopstr.Migrations
+{
+    [DbContext(typeof(ShopstrDbContext))]
+    [Migration("20260606_AddWooCommerce")]
+    public partial class AddWooCommerce : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WooCommerceSettings",
+                schema: "BTCPayServer.Plugins.Shopstr",
+                columns: table => new
+                {
+                    StoreId = table.Column<string>(nullable: false),
+                    WooCommerceUrl = table.Column<string>(nullable: false),
+                    ConsumerKey = table.Column<string>(nullable: false),
+                    ConsumerSecret = table.Column<string>(nullable: false),
+                    Location = table.Column<string>(nullable: true),
+                    FlashSales = table.Column<bool>(nullable: false, defaultValue: false),
+                    Condition = table.Column<int>(nullable: false, defaultValue: 0),
+                    Restrictions = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WooCommerceSettings", x => x.StoreId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WooCommerceSettings",
+                schema: "BTCPayServer.Plugins.Shopstr");
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Shopstr/Models/Shopstr/ShopstrViewModel.cs
+++ b/BTCPayServer.Plugins.Shopstr/Models/Shopstr/ShopstrViewModel.cs
@@ -8,6 +8,7 @@ namespace BTCPayServer.Plugins.Shopstr.Models.Shopstr
         public string storeId { get; set; }
         public Nip5StoreSettings Nip5Settings { get; set; }
         public List<ShopstrAppData> StoreApps { get; set; }
+        public WooCommerceSettings WooCommerceSettings { get; set; }
 
     }
 }

--- a/BTCPayServer.Plugins.Shopstr/Models/WooCommerceSettings.cs
+++ b/BTCPayServer.Plugins.Shopstr/Models/WooCommerceSettings.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+
+namespace BTCPayServer.Plugins.Shopstr.Models
+{
+    [PrimaryKey(nameof(StoreId))]
+    public class WooCommerceSettings
+    {
+        [Key]
+        public string StoreId { get; set; }
+
+        [Required]
+        public string WooCommerceUrl { get; set; }
+
+        [Required]
+        public string ConsumerKey { get; set; }
+
+        [Required]
+        public string ConsumerSecret { get; set; }
+
+        public string Location { get; set; }
+
+        public bool FlashSales { get; set; }
+
+        public ConditionEnum Condition { get; set; }
+
+        public string Restrictions { get; set; }
+
+        public bool IsConfigured => !string.IsNullOrEmpty(WooCommerceUrl)
+                                    && !string.IsNullOrEmpty(ConsumerKey)
+                                    && !string.IsNullOrEmpty(ConsumerSecret);
+    }
+}

--- a/BTCPayServer.Plugins.Shopstr/Plugin.cs
+++ b/BTCPayServer.Plugins.Shopstr/Plugin.cs
@@ -20,7 +20,8 @@ public class Plugin : BaseBTCPayServerPlugin
                 .AddHostedService<PluginMigrationRunner>()
                 .AddSingleton<ShopstrDbContextFactory>()
                 .AddSingleton<ShopstrService>()
-                .AddSingleton<ShopstrPluginService>();
+                .AddSingleton<ShopstrPluginService>()
+                .AddSingleton<WooCommerceService>();
 
     }
 

--- a/BTCPayServer.Plugins.Shopstr/Services/ShopstrPluginService.cs
+++ b/BTCPayServer.Plugins.Shopstr/Services/ShopstrPluginService.cs
@@ -54,7 +54,8 @@ namespace BTCPayServer.Plugins.Shopstr.Services
                 {
                     storeId = storeId,
                     Nip5Settings = await storeRepository.GetSettingAsync<Nip5StoreSettings>(storeId, "NIP05"),
-                    StoreApps = filteredApps
+                    StoreApps = filteredApps,
+                    WooCommerceSettings = await GetWooCommerceSettings(storeId)
                 };
 
             }
@@ -146,6 +147,50 @@ namespace BTCPayServer.Plugins.Shopstr.Services
             catch (Exception e)
             {
                 logger.LogError(e, "ShopstrPlugin:GetNostrSettings()");
+                throw;
+            }
+        }
+
+        public async Task<WooCommerceSettings> GetWooCommerceSettings(string storeId)
+        {
+            try
+            {
+                await using var context = dbContextFactory.CreateContext();
+                return await context.WooCommerceSettings.FirstOrDefaultAsync(a => a.StoreId == storeId);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "ShopstrPlugin:GetWooCommerceSettings()");
+                throw;
+            }
+        }
+
+        public async Task UpdateWooCommerceSettings(WooCommerceSettings settings)
+        {
+            try
+            {
+                await using var context = dbContextFactory.CreateContext();
+                var existing = await context.WooCommerceSettings.FirstOrDefaultAsync(a => a.StoreId == settings.StoreId);
+                if (existing == null)
+                {
+                    context.WooCommerceSettings.Add(settings);
+                }
+                else
+                {
+                    existing.WooCommerceUrl = settings.WooCommerceUrl;
+                    existing.ConsumerKey = settings.ConsumerKey;
+                    existing.ConsumerSecret = settings.ConsumerSecret;
+                    existing.Location = settings.Location;
+                    existing.FlashSales = settings.FlashSales;
+                    existing.Condition = settings.Condition;
+                    existing.Restrictions = settings.Restrictions;
+                    context.WooCommerceSettings.Update(existing);
+                }
+                await context.SaveChangesAsync();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "ShopstrPlugin:UpdateWooCommerceSettings()");
                 throw;
             }
         }

--- a/BTCPayServer.Plugins.Shopstr/Services/WooCommerceService.cs
+++ b/BTCPayServer.Plugins.Shopstr/Services/WooCommerceService.cs
@@ -1,0 +1,121 @@
+using BTCPayServer.Client.Models;
+using BTCPayServer.Plugins.Shopstr.Models;
+using BTCPayServer.Plugins.Shopstr.Models.Shopstr;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BTCPayServer.Plugins.Shopstr.Services
+{
+    public class WooCommerceService(ILogger<WooCommerceService> logger)
+    {
+        public async Task<ShopstrAppData> FetchProducts(WooCommerceSettings settings)
+        {
+            var products = new List<AppItem>();
+            var baseUrl = settings.WooCommerceUrl.TrimEnd('/');
+            var page = 1;
+            var perPage = 100;
+
+            using var client = new HttpClient();
+            var authBytes = Encoding.ASCII.GetBytes($"{settings.ConsumerKey}:{settings.ConsumerSecret}");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+
+            while (true)
+            {
+                var url = $"{baseUrl}/wp-json/wc/v3/products?status=publish&per_page={perPage}&page={page}";
+
+                try
+                {
+                    var response = await client.GetAsync(url);
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        var errorText = await response.Content.ReadAsStringAsync();
+                        logger.LogError("WooCommerce API error: {Status} - {Error}", response.StatusCode, errorText);
+                        break;
+                    }
+
+                    var json = await response.Content.ReadAsStringAsync();
+                    var wcProducts = JsonConvert.DeserializeObject<List<WcProduct>>(json);
+
+                    if (wcProducts == null || wcProducts.Count == 0)
+                        break;
+
+                    foreach (var wc in wcProducts)
+                    {
+                        products.Add(new AppItem
+                        {
+                            Id = wc.Id.ToString(),
+                            Title = wc.Name,
+                            Description = StripHtml(wc.ShortDescription ?? wc.Description ?? ""),
+                            Price = decimal.TryParse(wc.Price, out var p) ? p : 0,
+                            Image = wc.Images?.FirstOrDefault()?.Src ?? "",
+                            Disabled = wc.Status != "publish",
+                            Inventory = wc.StockQuantity ?? (wc.InStock ? 999 : 0),
+                            Categories = wc.Categories?.Select(c => c.Name).ToArray() ?? Array.Empty<string>(),
+                        });
+                    }
+
+                    if (wcProducts.Count < perPage)
+                        break;
+
+                    page++;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to fetch WooCommerce products (page {Page})", page);
+                    break;
+                }
+            }
+
+            logger.LogInformation("Fetched {Count} products from WooCommerce", products.Count);
+
+            return new ShopstrAppData
+            {
+                Id = "woocommerce",
+                Name = "WooCommerce",
+                CurrencyCode = "USD",
+                Location = settings.Location ?? "",
+                FlashSales = settings.FlashSales,
+                Condition = settings.Condition,
+                Restrictions = settings.Restrictions ?? "",
+                ShopItems = products
+            };
+        }
+
+        private static string StripHtml(string html)
+        {
+            if (string.IsNullOrEmpty(html)) return "";
+            return System.Text.RegularExpressions.Regex.Replace(html, "<.*?>", "").Trim();
+        }
+
+        private class WcProduct
+        {
+            [JsonProperty("id")] public int Id { get; set; }
+            [JsonProperty("name")] public string Name { get; set; }
+            [JsonProperty("status")] public string Status { get; set; }
+            [JsonProperty("description")] public string Description { get; set; }
+            [JsonProperty("short_description")] public string ShortDescription { get; set; }
+            [JsonProperty("price")] public string Price { get; set; }
+            [JsonProperty("stock_quantity")] public int? StockQuantity { get; set; }
+            [JsonProperty("in_stock")] public bool InStock { get; set; }
+            [JsonProperty("images")] public List<WcImage> Images { get; set; }
+            [JsonProperty("categories")] public List<WcCategory> Categories { get; set; }
+        }
+
+        private class WcImage
+        {
+            [JsonProperty("src")] public string Src { get; set; }
+        }
+
+        private class WcCategory
+        {
+            [JsonProperty("name")] public string Name { get; set; }
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Shopstr/Services/WooCommerceService.cs
+++ b/BTCPayServer.Plugins.Shopstr/Services/WooCommerceService.cs
@@ -23,12 +23,18 @@ namespace BTCPayServer.Plugins.Shopstr.Services
             var perPage = 100;
 
             using var client = new HttpClient();
-            var authBytes = Encoding.ASCII.GetBytes($"{settings.ConsumerKey}:{settings.ConsumerSecret}");
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+            var useBasicAuth = baseUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+            if (useBasicAuth)
+            {
+                var authBytes = Encoding.ASCII.GetBytes($"{settings.ConsumerKey}:{settings.ConsumerSecret}");
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+            }
 
             while (true)
             {
                 var url = $"{baseUrl}/wp-json/wc/v3/products?status=publish&per_page={perPage}&page={page}";
+                if (!useBasicAuth)
+                    url += $"&consumer_key={Uri.EscapeDataString(settings.ConsumerKey)}&consumer_secret={Uri.EscapeDataString(settings.ConsumerSecret)}";
 
                 try
                 {
@@ -48,6 +54,7 @@ namespace BTCPayServer.Plugins.Shopstr.Services
 
                     foreach (var wc in wcProducts)
                     {
+                        var inStock = wc.StockStatus == "instock" || wc.InStock;
                         products.Add(new AppItem
                         {
                             Id = wc.Id.ToString(),
@@ -55,8 +62,8 @@ namespace BTCPayServer.Plugins.Shopstr.Services
                             Description = StripHtml(wc.ShortDescription ?? wc.Description ?? ""),
                             Price = decimal.TryParse(wc.Price, out var p) ? p : 0,
                             Image = wc.Images?.FirstOrDefault()?.Src ?? "",
-                            Disabled = wc.Status != "publish",
-                            Inventory = wc.StockQuantity ?? (wc.InStock ? 999 : 0),
+                            Disabled = wc.Status != "publish" || !inStock,
+                            Inventory = wc.StockQuantity ?? (inStock ? 999 : 0),
                             Categories = wc.Categories?.Select(c => c.Name).ToArray() ?? Array.Empty<string>(),
                         });
                     }
@@ -104,6 +111,7 @@ namespace BTCPayServer.Plugins.Shopstr.Services
             [JsonProperty("price")] public string Price { get; set; }
             [JsonProperty("stock_quantity")] public int? StockQuantity { get; set; }
             [JsonProperty("in_stock")] public bool InStock { get; set; }
+            [JsonProperty("stock_status")] public string StockStatus { get; set; }
             [JsonProperty("images")] public List<WcImage> Images { get; set; }
             [JsonProperty("categories")] public List<WcCategory> Categories { get; set; }
         }

--- a/BTCPayServer.Plugins.Shopstr/Views/ShopstrPlugin/Index.cshtml
+++ b/BTCPayServer.Plugins.Shopstr/Views/ShopstrPlugin/Index.cshtml
@@ -218,6 +218,84 @@ else
 
 
 
+    <!-- WooCommerce Integration -->
+    <div class="card mb-4 mt-4">
+        <div class="card-header">
+            <strong>WooCommerce Integration</strong>
+        </div>
+        <div class="card-body">
+            @if (Model.WooCommerceSettings != null && Model.WooCommerceSettings.IsConfigured)
+            {
+                <div class="alert alert-success mb-3">
+                    <span class="me-2">&#10003;</span>
+                    Connected to <strong>@Model.WooCommerceSettings.WooCommerceUrl</strong>
+                </div>
+            }
+            <div class="row mb-3">
+                <div class="col-md-4">
+                    <label for="wcUrl" class="form-label">WooCommerce Store URL</label>
+                    <input id="wcUrl" type="url" class="form-control" placeholder="https://your-store.com" value="@(Model.WooCommerceSettings?.WooCommerceUrl ?? "")" />
+                </div>
+                <div class="col-md-4">
+                    <label for="wcKey" class="form-label">Consumer Key</label>
+                    <input id="wcKey" type="text" class="form-control" placeholder="ck_..." value="@(Model.WooCommerceSettings?.ConsumerKey ?? "")" />
+                </div>
+                <div class="col-md-4">
+                    <label for="wcSecret" class="form-label">Consumer Secret</label>
+                    <input id="wcSecret" type="password" class="form-control" placeholder="cs_..." value="@(Model.WooCommerceSettings?.ConsumerSecret ?? "")" />
+                </div>
+            </div>
+            <div class="row mb-3">
+                <div class="col-md-3">
+                    <label for="wcLocation" class="form-label">Location</label>
+                    <select id="wcLocation" class="form-select">
+                        <option value="" selected="@(string.IsNullOrEmpty(Model.WooCommerceSettings?.Location) ? "selected" : null)">Select a location</option>
+                        @foreach (var group in ShopstrSettings.AvailableLocations)
+                        {
+                            <optgroup label="@group.Key">
+                                @foreach (var location in group.Value)
+                                {
+                                    <option value="@location" selected="@(Model.WooCommerceSettings?.Location == location ? "selected" : null)">@location</option>
+                                }
+                            </optgroup>
+                        }
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label for="wcFlashSales" class="form-label">Flash Sales</label>
+                    <div class="form-check mt-2">
+                        <input id="wcFlashSales" class="form-check-input" type="checkbox" @(Model.WooCommerceSettings?.FlashSales == true ? "checked" : "") />
+                        <label class="form-check-label" for="wcFlashSales">Enabled</label>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <label for="wcCondition" class="form-label">Condition</label>
+                    <select id="wcCondition" class="form-select">
+                        @foreach (var condition in Enum.GetValues(typeof(ConditionEnum)))
+                        {
+                            var field = typeof(ConditionEnum).GetField(condition.ToString());
+                            var descAttr = (DescriptionAttribute)field.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault();
+                            var displayText = descAttr?.Description ?? condition.ToString();
+                            var isSelected = Model.WooCommerceSettings != null && (ConditionEnum)condition == Model.WooCommerceSettings.Condition;
+                            <option value="@condition" selected="@(isSelected ? "selected" : null)">@displayText</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label for="wcRestrictions" class="form-label">Restrictions</label>
+                    <input id="wcRestrictions" type="text" class="form-control" placeholder="US shipping only, etc." value="@(Model.WooCommerceSettings?.Restrictions ?? "")" />
+                </div>
+            </div>
+            <div class="d-flex gap-2">
+                <button id="BtSaveWc" class="btn btn-primary" onclick="SaveWcSettings()">Save WooCommerce Settings</button>
+                <button id="BtPublishWc" class="btn btn-secondary" onclick="DoPublishWc()">Publish WooCommerce Products</button>
+                <img id="WaitPublishWc" src="/Resources/img/waiting.webp" style="display:none" />
+                <button id="BtUnpublishWc" class="btn btn-secondary" onclick="DoUnpublishWc()">Unpublish</button>
+                <img id="WaitUnpublishWc" src="/Resources/img/waiting.webp" style="display:none" />
+            </div>
+        </div>
+    </div>
+
     @Html.AntiForgeryToken()
 
     <script type="text/javascript" >
@@ -289,6 +367,74 @@ else
                 alert("Error: " + error + " - " + xhr.responseText);
                 $('#WaitPublish' + appId).hide();
                 $('#BtPublish' + appId).show();
+            }
+        });
+    }
+
+    function SaveWcSettings() {
+        $('#BtSaveWc').hide();
+        $.ajax({
+            url: 'Shopstr/SaveWooCommerceSettings',
+            type: 'POST',
+            data: {
+                wooCommerceUrl: $('#wcUrl').val(),
+                consumerKey: $('#wcKey').val(),
+                consumerSecret: $('#wcSecret').val(),
+                location: $('#wcLocation').val(),
+                flashSales: $('#wcFlashSales').is(':checked'),
+                condition: $('#wcCondition').val(),
+                restrictions: $('#wcRestrictions').val()
+            },
+            headers: { 'RequestVerificationToken': antiForgeryToken },
+            success: function() {
+                alert("WooCommerce settings saved");
+                $('#BtSaveWc').show();
+            },
+            error: function(xhr, status, error) {
+                alert("Error: " + error + " - " + xhr.responseText);
+                $('#BtSaveWc').show();
+            }
+        });
+    }
+
+    function DoPublishWc() {
+        if (!confirm("Publish WooCommerce products to Shopstr marketplace?")) return;
+        $('#BtPublishWc').hide();
+        $('#WaitPublishWc').show();
+        $.ajax({
+            url: 'Shopstr/PublishWooCommerce',
+            type: 'POST',
+            headers: { 'RequestVerificationToken': antiForgeryToken },
+            success: function() {
+                alert("WooCommerce products published to Shopstr");
+                $('#WaitPublishWc').hide();
+                $('#BtPublishWc').show();
+            },
+            error: function(xhr, status, error) {
+                alert("Error: " + error + " - " + xhr.responseText);
+                $('#WaitPublishWc').hide();
+                $('#BtPublishWc').show();
+            }
+        });
+    }
+
+    function DoUnpublishWc() {
+        if (!confirm("Unpublish WooCommerce products from Shopstr marketplace?")) return;
+        $('#BtUnpublishWc').hide();
+        $('#WaitUnpublishWc').show();
+        $.ajax({
+            url: 'Shopstr/UnPublishWooCommerce',
+            type: 'POST',
+            headers: { 'RequestVerificationToken': antiForgeryToken },
+            success: function() {
+                alert("WooCommerce products unpublished from Shopstr");
+                $('#WaitUnpublishWc').hide();
+                $('#BtUnpublishWc').show();
+            },
+            error: function(xhr, status, error) {
+                alert("Error: " + error + " - " + xhr.responseText);
+                $('#WaitUnpublishWc').hide();
+                $('#BtUnpublishWc').show();
             }
         });
     }


### PR DESCRIPTION
## Summary
- Adds WooCommerce as an alternative product source alongside the existing BTCPay POS integration
- Merchants can connect their WooCommerce store via REST API (consumer key/secret) and publish products to the Shopstr/Nostr marketplace as kind:30402 events
- Includes full UI for WooCommerce settings (URL, API credentials, location, condition, restrictions, flash sales)
- Products fetched via WC REST API v3 with pagination support, mapped to the same `AppItem` format used by POS publishing

## Key implementation details
- Uses query param auth for HTTP URLs (WooCommerce requires HTTPS for Basic auth headers)
- Uses `stock_status` field from WC API v3 (not the deprecated boolean `in_stock`) to correctly mark products as active/sold
- WC_URL must match the WordPress `siteurl` option, not the server IP — WooCommerce rejects API requests that don't match

## Changes
- `WooCommerceSettings` model + DB migration for storing WC connection config per store
- `WooCommerceService` for fetching and mapping WC products (handles both HTTP and HTTPS auth)
- Controller endpoints: `SaveWooCommerceSettings`, `PublishWooCommerce`, `UnPublishWooCommerce`
- Updated plugin view with WooCommerce configuration section and publish/unpublish controls
- Registered `WooCommerceService` in plugin DI

## Test plan
- [ ] Configure WooCommerce API credentials in the Shopstr plugin settings
- [ ] Verify products are fetched from WooCommerce store
- [ ] Publish WooCommerce products to Shopstr and verify kind:30402 events on configured relays
- [ ] Verify products show correct stock status (active vs sold)
- [ ] Unpublish and verify products are removed from marketplace
- [ ] Confirm existing POS product publishing still works unchanged
- [ ] Test with both HTTP and HTTPS WooCommerce URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)